### PR TITLE
Adding attributes to Url class

### DIFF
--- a/waybackpy/wrapper.py
+++ b/waybackpy/wrapper.py
@@ -3,7 +3,6 @@
 import re
 import sys
 import json
-import warnings
 from datetime import datetime
 from waybackpy.exceptions import WaybackError
 from waybackpy.__version__ import __version__

--- a/waybackpy/wrapper.py
+++ b/waybackpy/wrapper.py
@@ -110,8 +110,8 @@ class Url:
         else:
             archive_url = data["archived_snapshots"]["closest"]["url"]
             archive_url = archive_url.replace(
-                "http://web.archive.org/web/", 
-                "https://web.archive.org/web/", 
+                "http://web.archive.org/web/",
+                "https://web.archive.org/web/",
                 1
             )
         
@@ -126,7 +126,7 @@ class Url:
         else:
             time = datetime.strptime(data["archived_snapshots"]
                                      ["closest"]
-                                     ["timestamp"], 
+                                     ["timestamp"],
                                      '%Y%m%d%H%M%S')
         
         return time

--- a/waybackpy/wrapper.py
+++ b/waybackpy/wrapper.py
@@ -3,6 +3,7 @@
 import re
 import sys
 import json
+import warnings
 from datetime import datetime
 from waybackpy.exceptions import WaybackError
 from waybackpy.__version__ import __version__
@@ -69,20 +70,67 @@ class Url:
         self.url = url
         self.user_agent = user_agent
         self._url_check()  # checks url validity on init.
-
+        self.JSON = self._JSON() # JSON of most recent archive
+        self.archive_url = self._archive_url() # URL of archive
+        self.timestamp = self._archive_timestamp() # timestamp for last archive
+        
     def __repr__(self):
         return "waybackpy.Url(url=%s, user_agent=%s)" % (self.url, self.user_agent)
 
     def __str__(self):
-        return "%s" % self._clean_url()
+        return "%s" % self.archive_url
 
     def __len__(self):
-        return len(self._clean_url())
+        diff = datetime.utcnow() - self.timestamp
+        return diff.days
 
     def _url_check(self):
         """Check for common URL problems."""
         if "." not in self.url:
             raise URLError("'%s' is not a vaild URL." % self.url)
+    
+    def _JSON(self):
+        request_url = "https://archive.org/wayback/available?url=%s" % (
+            self._clean_url(),
+        )
+
+        hdr = {"User-Agent": "%s" % self.user_agent}
+        req = Request(request_url, headers=hdr)  # nosec
+        response = _get_response(req)
+        data_string = response.read().decode("UTF-8")
+        data = json.loads(data_string)
+        
+        return data
+            
+    def _archive_url(self):
+        """Get URL of archive."""
+        data = self.JSON
+        
+        if not data["archived_snapshots"]:
+            archive_url = None
+        else:
+            archive_url = data["archived_snapshots"]["closest"]["url"]
+            archive_url = archive_url.replace(
+                "http://web.archive.org/web/", 
+                "https://web.archive.org/web/", 
+                1
+            )
+        
+        return archive_url
+        
+    def _archive_timestamp(self):
+        """Get timestamp of last archive."""
+        data = self.JSON
+        
+        if not data["archived_snapshots"]:
+            time = None
+        else:
+            time = datetime.strptime(data["archived_snapshots"]
+                                     ["closest"]
+                                     ["timestamp"], 
+                                     '%Y%m%d%H%M%S')
+        
+        return time
 
     def _clean_url(self):
         """Fix the URL, if possible."""
@@ -94,7 +142,9 @@ class Url:
         hdr = {"User-Agent": "%s" % self.user_agent}  # nosec
         req = Request(request_url, headers=hdr)  # nosec
         header = _get_response(req).headers
-        return "https://" + _archive_url_parser(header)
+        self.archive_url = "https://" + _archive_url_parser(header)
+        self.timestamp = datetime.utcnow()
+        return self
 
     def get(self, url="", user_agent="", encoding=""):
         """Return the source code of the supplied URL.
@@ -146,11 +196,18 @@ class Url:
                 "to create a new archive." % self._clean_url()
             )
         archive_url = data["archived_snapshots"]["closest"]["url"]
-        # wayback machine returns http sometimes, idk why? But they support https
         archive_url = archive_url.replace(
             "http://web.archive.org/web/", "https://web.archive.org/web/", 1
         )
-        return archive_url
+        
+        self.archive_url = archive_url
+        self.timestamp = datetime.strptime(data["archived_snapshots"]
+                                 ["closest"]
+                                 ["timestamp"], 
+                                 '%Y%m%d%H%M%S')
+         
+        return self
+        
 
     def oldest(self, year=1994):
         """Return the oldest Wayback Machine archive for this URL."""


### PR DESCRIPTION
Added the following attributes to Url:

1. `self.JSON`: JSON of latest archive so that others can access the data a little easier.
2. `self.archive_url`: Latest Archive URL (which is now shown when `print()` is used on `Url()`) so that the functionality described in the Readme still works but also can show immediately to users the archive URL without having to use `print()`.
3. `self.timestamp`: Timestamp of latest archive so that folks know how old the newest archive is. Using `len()` on Url shows the age of the archive in days now, too. 

The methods were edited to change attributes  2. and 3. and now return `self`. The Readme functionality is still preserved with the changes described above. 