### PR TITLE
Raise error on a 509 response (too many sessions)

### DIFF
--- a/waybackpy/wrapper.py
+++ b/waybackpy/wrapper.py
@@ -230,7 +230,8 @@ class Url:
 
         if response.status_code == 509:
             raise WaybackError(
-                "Can not save '{url}'. You have probably reached the limit of active sessions. Try later.".format(
+                "Can not save '{url}'. You have probably reached the limit of active "
+                "sessions. Try later.".format(
                     url=_cleaned_url(self.url), text=response.text
                 )
             )

--- a/waybackpy/wrapper.py
+++ b/waybackpy/wrapper.py
@@ -228,6 +228,13 @@ class Url:
             response=response,
         )
 
+        if response.status_code == 509:
+            raise WaybackError(
+                "Can not save '{url}'. You have probably reached the limit of active sessions. Try later.".format(
+                    url=_cleaned_url(self.url), text=response.text
+                )
+            )
+
         m = re.search(
             r"https?://web.archive.org/web/([0-9]{14})/http", self._archive_url
         )


### PR DESCRIPTION
When the response code is 509, raise an error with an explanation (based on the actual error message contained in the response HTML).