### PR TITLE
do not use f-strings in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ as f:
 
 version = str(about["__version__"])
 
-download_url = f"https://github.com/akamhy/waybackpy/archive/{version}.tar.gz"
+download_url = "https://github.com/akamhy/waybackpy/archive/{version}.tar.gz".format(version=version)
 
 setup(
     name=about["__title__"],


### PR DESCRIPTION
These are not supported in <Python 3.6 version of the cpython.