### PR TITLE
Fix syntax for opening the README.md and __version__.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,20 @@
 import os.path
 from setuptools import setup
 
-with open(
-    os.path.join(os.path.dirname(__file__), "README.md"), encoding="utf-8"),
-as f:
+readme_path = os.path.join(os.path.dirname(__file__), "README.md")
+with open(readme_path, encoding="utf-8") as f:
     long_description = f.read()
 
 about = {}
-with open(
-    os.path.join(os.path.dirname(__file__), "waybackpy", "__version__.py"),
-    encoding="utf-8")
-as f:
+version_path = os.path.join(os.path.dirname(__file__), "waybackpy", "__version__.py")
+with open(version_path, encoding="utf-8") as f:
     exec(f.read(), about)
 
 version = str(about["__version__"])
 
-download_url = "https://github.com/akamhy/waybackpy/archive/{version}.tar.gz".format(version=version)
+download_url = "https://github.com/akamhy/waybackpy/archive/{version}.tar.gz".format(
+    version=version
+)
 
 setup(
     name=about["__title__"],


### PR DESCRIPTION
For some reason updates made at https://github.com/akamhy/waybackpy/pull/114
are breaking the build using setup, caught while deploying to a cloud service
provider.

The exact error is:

```python
$  pip install git+https://github.com/akamhy/waybackpy.git
Collecting git+https://github.com/akamhy/waybackpy.git
  Cloning https://github.com/akamhy/waybackpy.git to /tmp/pip-req-build-n3b9e5pj
    ERROR: Command errored out with exit status 1:
     command: /tmp/ppp/venv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-req-build-n3b9e5pj/setup.py'"'"'; __file__='"'"'/tmp/pip-req-build-n3b9e5pj/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-dczej0bv
         cwd: /tmp/pip-req-build-n3b9e5pj/
    Complete output (6 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-n3b9e5pj/setup.py", line 5
        os.path.join(os.path.dirname(__file__), "README.md"), encoding="utf-8"),
                                                                                ^
    SyntaxError: invalid syntax
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
WARNING: You are using pip version 20.2.3; however, version 21.3.1 is available.
You should consider upgrading via the '/tmp/ppp/venv/bin/python -m pip install --upgrade pip' command.

```
See also :
https://github.com/conda-forge/staged-recipes/pull/17634