### PR TITLE
Improve pylint score

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -3,6 +3,9 @@ version = 1
 [[analyzers]]
 name = "python"
 enabled = true
-
+test_patterns = [
+  "tests/**",
+  "test_*.py"
+]
   [analyzers.meta]
   runtime_version = "3.x.x"

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -4,3 +4,4 @@ scanner:
 
 flake8:
     max-line-length: 88
+    extend-ignore: W503,W605

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ profile = black
 [flake8]
 indent-size = 4
 max-line-length = 88
-extend-ignore = W605
+extend-ignore = W503,W605
 
 [mypy]
 python_version = 3.9
@@ -84,7 +84,3 @@ addopts =
     --cov-report=html
 testpaths =
     tests
-
-[pycodestyle]
-# for `license` and `filter in `waybackpy.cli.main`
-ignore = W0622

--- a/tests/test_availability_api.py
+++ b/tests/test_availability_api.py
@@ -40,8 +40,8 @@ def test_oldest() -> None:
     oldest_timestamp = oldest.timestamp()
     assert abs(oldest_timestamp - now) > timedelta(days=7000)  # More than 19 years
     assert (
-        availability_api.JSON is not None
-        and availability_api.JSON["archived_snapshots"]["closest"]["available"] is True
+        availability_api.json is not None
+        and availability_api.json["archived_snapshots"]["closest"]["available"] is True
     )
     assert repr(oldest).find("example.com") != -1
     assert "2002" in str(oldest)

--- a/waybackpy/__init__.py
+++ b/waybackpy/__init__.py
@@ -1,6 +1,4 @@
-"""
-Module initializer and provider of static infomation.
-"""
+"""Module initializer and provider of static infomation."""
 
 __title__ = "waybackpy"
 __description__ = (

--- a/waybackpy/__init__.py
+++ b/waybackpy/__init__.py
@@ -1,3 +1,7 @@
+"""
+Module initializer and provider of static infomation.
+"""
+
 __title__ = "waybackpy"
 __description__ = (
     "Python package that interfaces with the Internet Archive's Wayback Machine APIs. "

--- a/waybackpy/availability_api.py
+++ b/waybackpy/availability_api.py
@@ -188,7 +188,10 @@ class WaybackMachineAvailabilityAPI:
                     "Archive not found in the availability "
                     "API response, the URL you requested may not have any archives "
                     "yet. You may retry after some time or archive the webpage now.\n"
-                    f"Response data:\n{None if self.response is None else self.response.text}"
+                    "Response data:\n"
+                    ""
+                    if self.response is None
+                    else self.response.text
                 )
         else:
             archive_url = data["archived_snapshots"]["closest"]["url"]

--- a/waybackpy/cdx_api.py
+++ b/waybackpy/cdx_api.py
@@ -24,7 +24,7 @@ from .exceptions import WaybackError
 from .utils import DEFAULT_USER_AGENT
 
 
-class WaybackMachineCDXServerAPI(object):
+class WaybackMachineCDXServerAPI:
     """
     Class that interfaces the CDX server API of the Wayback Machine.
 

--- a/waybackpy/cdx_snapshot.py
+++ b/waybackpy/cdx_snapshot.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import Dict
 
 
-class CDXSnapshot(object):
+class CDXSnapshot:
     """
     Class for the CDX snapshot lines('record') returned by the CDX API,
     Each valid line of the CDX API is casted to an CDXSnapshot object

--- a/waybackpy/cli.py
+++ b/waybackpy/cli.py
@@ -2,11 +2,11 @@
 Module that makes waybackpy a CLI tool.
 """
 
-import json as JSON
 import os
 import random
 import re
 import string
+from json import dumps
 from typing import Generator, List, Optional
 
 import click
@@ -40,7 +40,7 @@ def echo_availability_api(
     click.echo(archive_url)
     if json:
         click.echo("JSON response:")
-        click.echo(JSON.dumps(availability_api_instance.JSON))
+        click.echo(dumps(availability_api_instance.json))
 
 
 def save_urls_on_file(url_gen: Generator[str, None, None]) -> None:
@@ -63,7 +63,7 @@ def save_urls_on_file(url_gen: Generator[str, None, None]) -> None:
             domain = "domain-unknown" if match is None else match.group(1)
             file_name = f"{domain}-urls-{uid}.txt"
             file_path = os.path.join(os.getcwd(), file_name)
-            with open(file_path, "a") as file:
+            with open(file_path, "a", encoding="UTF-8") as file:
                 file.write(f"{url}\n")
 
         click.echo(url)
@@ -345,8 +345,8 @@ def main(  # pylint: disable=no-value-for-parameter
         if file:
             return save_urls_on_file(url_gen)
 
-        for url in url_gen:
-            click.echo(url)
+        for url_ in url_gen:
+            click.echo(url_)
 
     elif cdx:
         filters = list(cdx_filter)

--- a/waybackpy/wrapper.py
+++ b/waybackpy/wrapper.py
@@ -7,13 +7,15 @@ the Url class.
 from datetime import datetime, timedelta
 from typing import Generator, Optional
 
-from .availability_api import WaybackMachineAvailabilityAPI
+from requests.structures import CaseInsensitiveDict
+
+from .availability_api import ResponseJSON, WaybackMachineAvailabilityAPI
 from .cdx_api import WaybackMachineCDXServerAPI
 from .save_api import WaybackMachineSaveAPI
 from .utils import DEFAULT_USER_AGENT
 
 
-class Url(object):
+class Url:
     """
     The Url class is not recommended to be used anymore, instead use:
 
@@ -39,6 +41,9 @@ class Url(object):
         self.wayback_machine_availability_api = WaybackMachineAvailabilityAPI(
             self.url, user_agent=self.user_agent
         )
+        self.wayback_machine_save_api: Optional[WaybackMachineSaveAPI] = None
+        self.headers: Optional[CaseInsensitiveDict[str]] = None
+        self.json: Optional[ResponseJSON] = None
 
     def __str__(self) -> str:
         if not self.archive_url:
@@ -107,7 +112,7 @@ class Url(object):
     def set_availability_api_attrs(self) -> None:
         """Set the attributes for total backwards compatibility."""
         self.archive_url = self.wayback_machine_availability_api.archive_url
-        self.JSON = self.wayback_machine_availability_api.JSON
+        self.json = self.wayback_machine_availability_api.json
         self.timestamp = self.wayback_machine_availability_api.timestamp()
 
     def total_archives(


### PR DESCRIPTION
<details>

<summary>prev: 9.17/10</summary>

```
************* Module waybackpy
waybackpy/__init__.py:1:0: C0114: Missing module docstring (missing-module-docstring)
************* Module waybackpy.wrapper
waybackpy/wrapper.py:110:8: C0103: Attribute name "JSON" doesn't conform to snake_case naming style (invalid-name)
waybackpy/wrapper.py:16:0: R0205: Class 'Url' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
waybackpy/wrapper.py:16:0: R0902: Too many instance attributes (8/7) (too-many-instance-attributes)
waybackpy/wrapper.py:74:4: R0913: Too many arguments (7/5) (too-many-arguments)
waybackpy/wrapper.py:132:4: R0913: Too many arguments (6/5) (too-many-arguments)
waybackpy/wrapper.py:66:8: W0201: Attribute 'wayback_machine_save_api' defined outside __init__ (attribute-defined-outside-init)
waybackpy/wrapper.py:71:8: W0201: Attribute 'headers' defined outside __init__ (attribute-defined-outside-init)
waybackpy/wrapper.py:110:8: W0201: Attribute 'JSON' defined outside __init__ (attribute-defined-outside-init)
************* Module waybackpy.cdx_api
waybackpy/cdx_api.py:27:0: R0205: Class 'WaybackMachineCDXServerAPI' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
waybackpy/cdx_api.py:27:0: R0902: Too many instance attributes (13/7) (too-many-instance-attributes)
waybackpy/cdx_api.py:39:4: R0913: Too many arguments (11/5) (too-many-arguments)
************* Module waybackpy.cdx_snapshot
waybackpy/cdx_snapshot.py:14:0: R0205: Class 'CDXSnapshot' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
waybackpy/cdx_snapshot.py:14:0: R0902: Too many instance attributes (9/7) (too-many-instance-attributes)
waybackpy/cdx_snapshot.py:14:0: R0903: Too few public methods (1/2) (too-few-public-methods)
************* Module waybackpy.save_api
waybackpy/save_api.py:22:0: R0205: Class 'WaybackMachineSaveAPI' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
waybackpy/save_api.py:22:0: R0902: Too many instance attributes (16/7) (too-many-instance-attributes)
waybackpy/save_api.py:84:8: W0201: Attribute 'response' defined outside __init__ (attribute-defined-outside-init)
waybackpy/save_api.py:86:8: W0201: Attribute 'headers' defined outside __init__ (attribute-defined-outside-init)
waybackpy/save_api.py:87:8: W0201: Attribute 'status_code' defined outside __init__ (attribute-defined-outside-init)
waybackpy/save_api.py:88:8: W0201: Attribute 'response_url' defined outside __init__ (attribute-defined-outside-init)
waybackpy/save_api.py:132:8: W0201: Attribute 'response_url' defined outside __init__ (attribute-defined-outside-init)
waybackpy/save_api.py:185:12: W0201: Attribute 'cached_save' defined outside __init__ (attribute-defined-outside-init)
waybackpy/save_api.py:187:12: W0201: Attribute 'cached_save' defined outside __init__ (attribute-defined-outside-init)
waybackpy/save_api.py:200:8: W0201: Attribute 'saved_archive' defined outside __init__ (attribute-defined-outside-init)
waybackpy/save_api.py:208:12: W0201: Attribute 'saved_archive' defined outside __init__ (attribute-defined-outside-init)
************* Module waybackpy.cli
waybackpy/cli.py:66:17: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
waybackpy/cli.py:211:0: R0913: Too many arguments (27/5) (too-many-arguments)
waybackpy/cli.py:211:0: R0914: Too many local variables (42/15) (too-many-locals)
waybackpy/cli.py:295:8: R0916: Too many boolean expressions in if statement (7/5) (too-many-boolean-expressions)
waybackpy/cli.py:348:12: R1704: Redefining argument with the local name 'url' (redefined-argument-from-local)
waybackpy/cli.py:211:0: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
waybackpy/cli.py:211:0: R0912: Too many branches (26/12) (too-many-branches)
waybackpy/cli.py:211:0: R0915: Too many statements (68/50) (too-many-statements)
************* Module waybackpy.availability_api
waybackpy/availability_api.py:58:8: C0103: Attribute name "JSON" doesn't conform to snake_case naming style (invalid-name)
waybackpy/availability_api.py:40:0: R0205: Class 'WaybackMachineAvailabilityAPI' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
waybackpy/availability_api.py:40:0: R0902: Too many instance attributes (11/7) (too-many-instance-attributes)
waybackpy/availability_api.py:143:12: R0916: Too many boolean expressions in if statement (6/5) (too-many-boolean-expressions)
waybackpy/availability_api.py:230:4: R0913: Too many arguments (7/5) (too-many-arguments)
waybackpy/availability_api.py:112:8: W0201: Attribute 'response' defined outside __init__ (attribute-defined-outside-init)
waybackpy/availability_api.py:1:0: R0401: Cyclic import (waybackpy -> waybackpy.availability_api -> waybackpy.utils) (cyclic-import)
waybackpy/availability_api.py:1:0: R0401: Cyclic import (waybackpy -> waybackpy.wrapper -> waybackpy.utils) (cyclic-import)
waybackpy/availability_api.py:1:0: R0401: Cyclic import (waybackpy -> waybackpy.wrapper -> waybackpy.cdx_api -> waybackpy.cdx_utils -> waybackpy.utils) (cyclic-import)
waybackpy/availability_api.py:1:0: R0401: Cyclic import (waybackpy -> waybackpy.wrapper -> waybackpy.cdx_api -> waybackpy.utils) (cyclic-import)
waybackpy/availability_api.py:1:0: R0401: Cyclic import (waybackpy -> waybackpy.save_api -> waybackpy.utils) (cyclic-import)
waybackpy/availability_api.py:1:0: R0801: Similar lines in 2 files
==waybackpy.availability_api:[229:237]
==waybackpy.wrapper:[73:81]
    def near(
        self,
        year: Optional[int] = None,
        month: Optional[int] = None,
        day: Optional[int] = None,
        hour: Optional[int] = None,
        minute: Optional[int] = None,
        unix_timestamp: Optional[int] = None, (duplicate-code)
waybackpy/availability_api.py:1:0: R0801: Similar lines in 2 files
==waybackpy.cli:[249:254]
==waybackpy.wrapper:[75:80]
    year: Optional[int] = None,
    month: Optional[int] = None,
    day: Optional[int] = None,
    hour: Optional[int] = None,
    minute: Optional[int] = None, (duplicate-code)

------------------------------------------------------------------
Your code has been rated at 9.17/10 (previous run: 8.34/10, +0.83)
```

</details>

<details>

<summary>after: 9.60/10</summary>

```
************* Module waybackpy.wrapper
waybackpy/wrapper.py:18:0: R0902: Too many instance attributes (8/7) (too-many-instance-attributes)
waybackpy/wrapper.py:79:4: R0913: Too many arguments (7/5) (too-many-arguments)
waybackpy/wrapper.py:137:4: R0913: Too many arguments (6/5) (too-many-arguments)
************* Module waybackpy.cdx_api
waybackpy/cdx_api.py:27:0: R0902: Too many instance attributes (13/7) (too-many-instance-attributes)
waybackpy/cdx_api.py:39:4: R0913: Too many arguments (11/5) (too-many-arguments)
************* Module waybackpy.cdx_snapshot
waybackpy/cdx_snapshot.py:14:0: R0902: Too many instance attributes (9/7) (too-many-instance-attributes)
waybackpy/cdx_snapshot.py:14:0: R0903: Too few public methods (1/2) (too-few-public-methods)
************* Module waybackpy.save_api
waybackpy/save_api.py:23:0: R0902: Too many instance attributes (16/7) (too-many-instance-attributes)
************* Module waybackpy.cli
waybackpy/cli.py:211:0: R0913: Too many arguments (27/5) (too-many-arguments)
waybackpy/cli.py:211:0: R0914: Too many local variables (43/15) (too-many-locals)
waybackpy/cli.py:295:8: R0916: Too many boolean expressions in if statement (7/5) (too-many-boolean-expressions)
waybackpy/cli.py:211:0: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
waybackpy/cli.py:211:0: R0912: Too many branches (26/12) (too-many-branches)
waybackpy/cli.py:211:0: R0915: Too many statements (68/50) (too-many-statements)
************* Module waybackpy.availability_api
waybackpy/availability_api.py:40:0: R0902: Too many instance attributes (11/7) (too-many-instance-attributes)
waybackpy/availability_api.py:144:12: R0916: Too many boolean expressions in if statement (6/5) (too-many-boolean-expressions)
waybackpy/availability_api.py:231:4: R0913: Too many arguments (7/5) (too-many-arguments)
waybackpy/availability_api.py:1:0: R0401: Cyclic import (waybackpy -> waybackpy.save_api -> waybackpy.utils) (cyclic-import)
waybackpy/availability_api.py:1:0: R0401: Cyclic import (waybackpy -> waybackpy.wrapper -> waybackpy.availability_api -> waybackpy.utils) (cyclic-import)
waybackpy/availability_api.py:1:0: R0401: Cyclic import (waybackpy -> waybackpy.availability_api -> waybackpy.utils) (cyclic-import)
waybackpy/availability_api.py:1:0: R0401: Cyclic import (waybackpy -> waybackpy.cdx_api -> waybackpy.cdx_utils -> waybackpy.utils) (cyclic-import)
waybackpy/availability_api.py:1:0: R0801: Similar lines in 2 files
==waybackpy.availability_api:[230:238]
==waybackpy.wrapper:[78:86]
    def near(
        self,
        year: Optional[int] = None,
        month: Optional[int] = None,
        day: Optional[int] = None,
        hour: Optional[int] = None,
        minute: Optional[int] = None,
        unix_timestamp: Optional[int] = None, (duplicate-code)
waybackpy/availability_api.py:1:0: R0801: Similar lines in 2 files
==waybackpy.cli:[249:254]
==waybackpy.wrapper:[80:85]
    year: Optional[int] = None,
    month: Optional[int] = None,
    day: Optional[int] = None,
    hour: Optional[int] = None,
    minute: Optional[int] = None, (duplicate-code)

------------------------------------------------------------------
Your code has been rated at 9.60/10 (previous run: 9.59/10, +0.02)
```

</details>

