### PR TITLE
Add typed marker (PEP561)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,11 +41,15 @@ classifiers =
 
 [options]
 packages = find:
+include-package-data = True
 python_requires = >= 3.6
 install_requires =
     click
     requests
     urllib3
+
+[options.package_data]
+waybackpy = py.typed
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0561/#id13

>In order to make packaging and distributing type information as simple and easy as possible, packaging and distribution is done through existing frameworks.
>
>Package maintainers who wish to support type checking of their code MUST add a marker file named py.typed to their package supporting typing. This marker applies recursively: if a top-level package includes it, all its sub-packages MUST support type checking as well. To have this file installed with the package, maintainers can use existing packaging options such as package_data in distutils, shown below.

