### PR TITLE
Add Python 3.11 to setup.cfg classifiers list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
 
 [options]


### PR DESCRIPTION
I have verified that tests are passing.