### PR TITLE
Robust parsing for malformed Wayback timestamps

### DIFF
--- a/tests/test_availability_api.py
+++ b/tests/test_availability_api.py
@@ -111,3 +111,27 @@ def test_no_call_timestamp() -> None:
         url=f"https://{rndstr(30)}.in", user_agent=user_agent
     )
     assert datetime.max == availability_api.timestamp()
+
+def test_availability_timestamp_uses_robust_parser() -> None:
+    """
+    WaybackMachineAvailabilityAPI.timestamp should correctly handle timestamps
+    that require normalization via parse_wayback_datetime (e.g. day '00').
+    """
+    availability_api = WaybackMachineAvailabilityAPI(
+        url="https://example.com/", user_agent=user_agent
+    )
+
+    ts_str = "20000900190155"  # 2000‑09‑01 19:01:55 after normalization
+    availability_api.json = {
+        "archived_snapshots": {
+            "closest": {
+                "available": True,
+                "timestamp": ts_str,
+                "url": (
+                    "https://web.archive.org/web/20000900190155/"
+                    "https://example.com/"
+                ),
+            }
+        }
+    }
+    assert availability_api.timestamp() == datetime(2000, 9, 1, 19, 1, 55)

--- a/tests/test_availability_api.py
+++ b/tests/test_availability_api.py
@@ -112,6 +112,7 @@ def test_no_call_timestamp() -> None:
     )
     assert datetime.max == availability_api.timestamp()
 
+
 def test_availability_timestamp_uses_robust_parser() -> None:
     """
     WaybackMachineAvailabilityAPI.timestamp should correctly handle timestamps
@@ -128,8 +129,7 @@ def test_availability_timestamp_uses_robust_parser() -> None:
                 "available": True,
                 "timestamp": ts_str,
                 "url": (
-                    "https://web.archive.org/web/20000900190155/"
-                    "https://example.com/"
+                    "https://web.archive.org/web/20000900190155/" "https://example.com/"
                 ),
             }
         }

--- a/tests/test_cdx_snapshot.py
+++ b/tests/test_cdx_snapshot.py
@@ -44,6 +44,7 @@ def test_CDXSnapshot() -> None:
     assert sample_input == str(snapshot)
     assert sample_input == repr(snapshot)
 
+
 def test_CDXSnapshot_with_non_standard_timestamp() -> None:
     """
     CDXSnapshot should use parse_wayback_datetime and cope with timestamps

--- a/tests/test_cdx_snapshot.py
+++ b/tests/test_cdx_snapshot.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Dict
 
 from waybackpy.cdx_snapshot import CDXSnapshot
 
@@ -42,3 +43,28 @@ def test_CDXSnapshot() -> None:
     assert archive_url == snapshot.archive_url
     assert sample_input == str(snapshot)
     assert sample_input == repr(snapshot)
+
+def test_CDXSnapshot_with_non_standard_timestamp() -> None:
+    """
+    CDXSnapshot should use parse_wayback_datetime and cope with timestamps
+    that need normalization (e.g. day '00').
+    """
+    sample_input = (
+        "org,archive)/ 20000900190155 http://github.com "
+        "text/html 200 Q4YULN754FHV2U6Q5JUT6Q2P57WEWNNY 1415"
+    )
+    prop_values = sample_input.split(" ")
+    properties: Dict[str, str] = {}
+    (
+        properties["urlkey"],
+        properties["timestamp"],
+        properties["original"],
+        properties["mimetype"],
+        properties["statuscode"],
+        properties["digest"],
+        properties["length"],
+    ) = prop_values
+
+    snapshot = CDXSnapshot(properties)
+    assert snapshot.datetime_timestamp == datetime(2000, 9, 1, 19, 1, 55)
+    assert snapshot.timestamp == "20000900190155"

--- a/tests/test_save_api.py
+++ b/tests/test_save_api.py
@@ -222,6 +222,7 @@ def test_archive_url() -> None:
     save_api._archive_url = save_api.saved_archive
     assert save_api.archive_url == save_api.saved_archive
 
+
 def test_timestamp_with_non_standard_wayback_timestamp() -> None:
     """
     WaybackMachineSaveAPI.timestamp should use parse_wayback_datetime and

--- a/tests/test_save_api.py
+++ b/tests/test_save_api.py
@@ -221,3 +221,26 @@ def test_archive_url() -> None:
     )
     save_api._archive_url = save_api.saved_archive
     assert save_api.archive_url == save_api.saved_archive
+
+def test_timestamp_with_non_standard_wayback_timestamp() -> None:
+    """
+    WaybackMachineSaveAPI.timestamp should use parse_wayback_datetime and
+    correctly normalize timestamps with '00' day etc.
+    """
+    url = "https://example.com"
+    user_agent = (
+        "Mozilla/5.0 (MacBook Air; M1 Mac OS X 11_4) AppleWebKit/605.1.15 "
+        "(KHTML, like Gecko) Version/14.1.1 Safari/604.1"
+    )
+    save_api = WaybackMachineSaveAPI(url, user_agent)
+
+    ts = "20000900190155"  # 2000‑09‑01 19:01:55 after normalization
+    save_api._archive_url = f"https://web.archive.org/web/{ts}/{url}/"
+
+    # Ensure the instance birth time is after the archive timestamp so that
+    # cached_save becomes True deterministically.
+    save_api.instance_birth_time = datetime(2001, 1, 1, 0, 0, 0)
+
+    parsed = save_api.timestamp()
+    assert parsed == datetime(2000, 9, 1, 19, 1, 55)
+    assert save_api.cached_save is True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ def test_default_user_agent() -> None:
         == f"waybackpy {__version__} - https://github.com/akamhy/waybackpy"
     )
 
+
 def test_parse_wayback_datetime_14_digits() -> None:
     """Standard 14‑digit Wayback timestamp parses as‑is."""
     ts = "20220102130405"
@@ -70,7 +71,6 @@ def test_parse_wayback_datetime_clamps_time_components() -> None:
         "123456789012345",  # 15 digits
     ],
 )
-
 def test_parse_wayback_datetime_invalid_input_raises(ts: str) -> None:
     """Non‑conforming strings should raise ValueError."""
     with pytest.raises(ValueError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,9 @@
+from datetime import datetime
+
+import pytest
+
 from waybackpy import __version__
-from waybackpy.utils import DEFAULT_USER_AGENT
+from waybackpy.utils import DEFAULT_USER_AGENT, parse_wayback_datetime
 
 
 def test_default_user_agent() -> None:
@@ -7,3 +11,67 @@ def test_default_user_agent() -> None:
         DEFAULT_USER_AGENT
         == f"waybackpy {__version__} - https://github.com/akamhy/waybackpy"
     )
+
+def test_parse_wayback_datetime_14_digits() -> None:
+    """Standard 14‑digit Wayback timestamp parses as‑is."""
+    ts = "20220102130405"
+    dt = parse_wayback_datetime(ts)
+    assert dt == datetime(2022, 1, 2, 13, 4, 5)
+
+
+def test_parse_wayback_datetime_12_digits() -> None:
+    """
+    12‑digit timestamps (YYYYMMDDhhmm) are accepted and seconds are assumed 00.
+    """
+    ts = "202201021304"
+    dt = parse_wayback_datetime(ts)
+    assert dt == datetime(2022, 1, 2, 13, 4, 0)
+
+
+def test_parse_wayback_datetime_normalizes_zero_day() -> None:
+    """
+    Timestamps with day '00' are normalized to day 1.
+    Example from the docstring: '20000900190155' -> 2000‑09‑01 19:01:55.
+    """
+    ts = "20000900190155"
+    dt = parse_wayback_datetime(ts)
+    assert dt == datetime(2000, 9, 1, 19, 1, 55)
+
+
+def test_parse_wayback_datetime_normalizes_invalid_day_and_month() -> None:
+    """
+    Out‑of‑range month and day values are clamped into valid ranges.
+    """
+    # Month 13 -> 12, day 32 -> last day of month (31 for December 2024)
+    ts = "20241332000000"
+    dt = parse_wayback_datetime(ts)
+    assert dt == datetime(2024, 12, 31, 0, 0, 0)
+
+    # February 30 2024 -> February 29 2024 (leap year)
+    ts_feb = "20240230000000"
+    dt_feb = parse_wayback_datetime(ts_feb)
+    assert dt_feb == datetime(2024, 2, 29, 0, 0, 0)
+
+
+def test_parse_wayback_datetime_clamps_time_components() -> None:
+    """Hours/minutes/seconds are clamped into valid ranges."""
+    ts = "20220101199999"  # 19 -> 19, 99 -> 59, 99 -> 59
+    dt = parse_wayback_datetime(ts)
+    assert dt == datetime(2022, 1, 1, 19, 59, 59)
+
+
+@pytest.mark.parametrize(
+    "ts",
+    [
+        "",
+        "abc",
+        "2022-01-01",
+        "1234567890123",  # 13 digits, neither 12 nor 14
+        "123456789012345",  # 15 digits
+    ],
+)
+
+def test_parse_wayback_datetime_invalid_input_raises(ts: str) -> None:
+    """Non‑conforming strings should raise ValueError."""
+    with pytest.raises(ValueError):
+        parse_wayback_datetime(ts)

--- a/waybackpy/availability_api.py
+++ b/waybackpy/availability_api.py
@@ -36,6 +36,7 @@ from .utils import (
     DEFAULT_USER_AGENT,
     unix_timestamp_to_wayback_timestamp,
     wayback_timestamp,
+    parse_wayback_datetime,
 )
 
 ResponseJSON = Dict[str, Any]
@@ -139,9 +140,8 @@ class WaybackMachineAvailabilityAPI:
             and self.json["archived_snapshots"]["closest"] is not None
             and "timestamp" in self.json["archived_snapshots"]["closest"]
         ):
-            return datetime.strptime(
-                self.json["archived_snapshots"]["closest"]["timestamp"], "%Y%m%d%H%M%S"
-            )
+            ts = self.json["archived_snapshots"]["closest"]["timestamp"]
+            return parse_wayback_datetime(ts)
 
         raise ValueError("Timestamp not found in the Availability API's JSON response.")
 

--- a/waybackpy/cdx_api.py
+++ b/waybackpy/cdx_api.py
@@ -8,7 +8,6 @@ WaybackMachineCDXServerAPI has a snapshot method that yields the snapshots, and
 the snapshots are yielded as instances of the CDXSnapshot class.
 """
 
-
 import time
 from datetime import datetime
 from typing import Dict, Generator, List, Optional, Union, cast

--- a/waybackpy/cdx_snapshot.py
+++ b/waybackpy/cdx_snapshot.py
@@ -6,7 +6,6 @@ The CDX index format is plain text data. Each line ('record') indicates a
 crawled document. And these lines are casted to CDXSnapshot.
 """
 
-
 from datetime import datetime
 from typing import Dict
 from .utils import parse_wayback_datetime

--- a/waybackpy/cdx_snapshot.py
+++ b/waybackpy/cdx_snapshot.py
@@ -9,6 +9,7 @@ crawled document. And these lines are casted to CDXSnapshot.
 
 from datetime import datetime
 from typing import Dict
+from .utils import parse_wayback_datetime
 
 
 class CDXSnapshot:
@@ -61,9 +62,7 @@ class CDXSnapshot:
     def __init__(self, properties: Dict[str, str]) -> None:
         self.urlkey: str = properties["urlkey"]
         self.timestamp: str = properties["timestamp"]
-        self.datetime_timestamp: datetime = datetime.strptime(
-            self.timestamp, "%Y%m%d%H%M%S"
-        )
+        self.datetime_timestamp: datetime = parse_wayback_datetime(self.timestamp)
         self.original: str = properties["original"]
         self.mimetype: str = properties["mimetype"]
         self.statuscode: str = properties["statuscode"]

--- a/waybackpy/save_api.py
+++ b/waybackpy/save_api.py
@@ -17,7 +17,7 @@ from requests.structures import CaseInsensitiveDict
 from urllib3.util.retry import Retry
 
 from .exceptions import MaximumSaveRetriesExceeded, TooManyRequestsError, WaybackError
-from .utils import DEFAULT_USER_AGENT
+from .utils import DEFAULT_USER_AGENT, parse_wayback_datetime
 
 
 class WaybackMachineSaveAPI:
@@ -181,7 +181,7 @@ class WaybackMachineSaveAPI:
             )
 
         string_timestamp = match.group(1)
-        timestamp = datetime.strptime(string_timestamp, "%Y%m%d%H%M%S")
+        timestamp = parse_wayback_datetime(string_timestamp)
         timestamp_unixtime = time.mktime(timestamp.timetuple())
         instance_birth_time_unixtime = time.mktime(self.instance_birth_time.timetuple())
 

--- a/waybackpy/utils.py
+++ b/waybackpy/utils.py
@@ -30,6 +30,7 @@ def wayback_timestamp(**kwargs: int) -> str:
         str(kwargs[key]).zfill(2) for key in ["year", "month", "day", "hour", "minute"]
     )
 
+
 def parse_wayback_datetime(ts: str) -> datetime:
     """
     Parse a Wayback timestamp robustly.

--- a/waybackpy/utils.py
+++ b/waybackpy/utils.py
@@ -63,37 +63,3 @@ def parse_wayback_datetime(ts: str) -> datetime:
     S = min(max(S, 0), 59)
 
     return datetime(y, m, d, H, M, S)
-
-def parse_wayback_datetime(ts: str) -> datetime:
-    """
-    Parse a Wayback timestamp robustly.
-    Accepts 14 digits (YYYYMMDDhhmmss) or 12 digits (YYYYMMDDhhmm),
-    normalizes '00' month/day etc. to valid calendar values.
-
-    Examples:
-      '20000900190155' -> 2000-09-01 19:01:55   (day 00 -> 01)
-    """
-    ts = ts.strip()
-
-    # Allow 12-digit timestamps by assuming seconds=00
-    if re.fullmatch(r"\d{12}", ts):
-        ts = ts + "00"
-    if not re.fullmatch(r"\d{14}", ts):
-        raise ValueError(f"Invalid Wayback timestamp: '{ts}'")
-
-    y = int(ts[0:4])
-    m = int(ts[4:6])
-    d = int(ts[6:8])
-    H = int(ts[8:10])
-    M = int(ts[10:12])
-    S = int(ts[12:14])
-
-    # Normalize out-of-range values (notably 00 for month/day)
-    m = 1 if m == 0 else min(max(m, 1), 12)
-    last_day = calendar.monthrange(y, m)[1]
-    d = 1 if d == 0 else min(max(d, 1), last_day)
-    H = min(max(H, 0), 23)
-    M = min(max(M, 0), 59)
-    S = min(max(S, 0), 59)
-
-    return datetime(y, m, d, H, M, S)

--- a/waybackpy/utils.py
+++ b/waybackpy/utils.py
@@ -3,6 +3,8 @@ Utility functions and shared variables like DEFAULT_USER_AGENT are here.
 """
 
 from datetime import datetime
+import calendar
+import re
 
 from . import __version__
 
@@ -27,3 +29,71 @@ def wayback_timestamp(**kwargs: int) -> str:
     return "".join(
         str(kwargs[key]).zfill(2) for key in ["year", "month", "day", "hour", "minute"]
     )
+
+def parse_wayback_datetime(ts: str) -> datetime:
+    """
+    Parse a Wayback timestamp robustly.
+    Accepts 14 digits (YYYYMMDDhhmmss) or 12 digits (YYYYMMDDhhmm),
+    normalizes '00' month/day etc. to valid calendar values.
+
+    Examples:
+      '20000900190155' -> 2000-09-01 19:01:55   (day 00 -> 01)
+    """
+    ts = ts.strip()
+
+    # Allow 12-digit timestamps by assuming seconds=00
+    if re.fullmatch(r"\d{12}", ts):
+        ts = ts + "00"
+    if not re.fullmatch(r"\d{14}", ts):
+        raise ValueError(f"Invalid Wayback timestamp: '{ts}'")
+
+    y = int(ts[0:4])
+    m = int(ts[4:6])
+    d = int(ts[6:8])
+    H = int(ts[8:10])
+    M = int(ts[10:12])
+    S = int(ts[12:14])
+
+    # Normalize out-of-range values (notably 00 for month/day)
+    m = 1 if m == 0 else min(max(m, 1), 12)
+    last_day = calendar.monthrange(y, m)[1]
+    d = 1 if d == 0 else min(max(d, 1), last_day)
+    H = min(max(H, 0), 23)
+    M = min(max(M, 0), 59)
+    S = min(max(S, 0), 59)
+
+    return datetime(y, m, d, H, M, S)
+
+def parse_wayback_datetime(ts: str) -> datetime:
+    """
+    Parse a Wayback timestamp robustly.
+    Accepts 14 digits (YYYYMMDDhhmmss) or 12 digits (YYYYMMDDhhmm),
+    normalizes '00' month/day etc. to valid calendar values.
+
+    Examples:
+      '20000900190155' -> 2000-09-01 19:01:55   (day 00 -> 01)
+    """
+    ts = ts.strip()
+
+    # Allow 12-digit timestamps by assuming seconds=00
+    if re.fullmatch(r"\d{12}", ts):
+        ts = ts + "00"
+    if not re.fullmatch(r"\d{14}", ts):
+        raise ValueError(f"Invalid Wayback timestamp: '{ts}'")
+
+    y = int(ts[0:4])
+    m = int(ts[4:6])
+    d = int(ts[6:8])
+    H = int(ts[8:10])
+    M = int(ts[10:12])
+    S = int(ts[12:14])
+
+    # Normalize out-of-range values (notably 00 for month/day)
+    m = 1 if m == 0 else min(max(m, 1), 12)
+    last_day = calendar.monthrange(y, m)[1]
+    d = 1 if d == 0 else min(max(d, 1), last_day)
+    H = min(max(H, 0), 23)
+    M = min(max(M, 0), 59)
+    S = min(max(S, 0), 59)
+
+    return datetime(y, m, d, H, M, S)


### PR DESCRIPTION
Wayback’s APIs sometimes return non-standard timestamps like `20100100190155` (day `00`) or 12-digit values without seconds. These used to be parsed directly with `datetime.strptime`, causing `ValueError`s and halting the whole executrion

This change introduces a shared `parse_wayback_datetime` helper n `utils.py`; and switches all Wayback timestamp parsing to use it, so timestamps are now handled centrally instead of via scattered `datetime.strptime` calls. The helper accepts 14-digit and 12-digit timestamps, normalizes values like `2010-07-00`, and prevents malformed Wayback timestamps from raising exceptions that previously could halt execution in the availability, CDX, or save flows.
